### PR TITLE
debug: Solve the problem that kubeconfig is not found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ mkdir -p /tmp/k8s_storage_perf/work-dir
 cp ./params.yml /tmp/k8s_storage_perf/work-dir/params.yml
 
 ${dockerexe} pull ${docker_image}
-${dockerexe} run --name ${container_name} -d -v /tmp/k8s_storage_perf/work-dir:/tmp/work-dir ${docker_image}
+${dockerexe} run --name ${container_name} -d -v /tmp/k8s_storage_perf/work-dir:/tmp/work-dir -v /root/.kube/config:/root/.kube/config:Z -e KUBECONFIG=/root/.kube/config ${docker_image}
 ```
 
 #### Run the Playbook


### PR DESCRIPTION
Hi, In my openshift cluster, I ran k8s-storage-perf through the container and found that kubeconfig was not found. An error was reported during the execution process:[#37](https://github.com/IBM/k8s-storage-perf/issues/37) and there is no configuration about kubeconfig in the code and manual. Therefore, this may be a bug. I passed I solved this problem by adding the mount kubeconfig directory and declaring the variable KUBECONFIG in the running container.